### PR TITLE
feat(app): dialog nativ pentru locatie

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -31,4 +31,6 @@
     <plugin name="cordova-sqlite-storage" spec="~2.0.0" />
     <plugin name="cordova-plugin-x-socialsharing" spec="~5.1.3" />
     <plugin name="cordova-plugin-directions" spec="~0.4.4" />
+    <plugin name="cordova-plugin-dialogs" spec="~1.3.0" />
+    <plugin name="cordova.plugins.diagnostic" spec="~3.3.2" />
 </widget>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,6 @@
 import { Component, ViewChild } from '@angular/core';
 import { Nav, Platform } from 'ionic-angular';
-import { StatusBar, Splashscreen } from 'ionic-native';
+import { StatusBar, Splashscreen, Diagnostic, Dialogs } from 'ionic-native';
 
 import { PageMap } from '../pages/map/map';
 import { PageFAQ } from '../pages/faq/faq';
@@ -28,10 +28,18 @@ export class MyApp {
 
   initializeApp() {
     this.platform.ready().then(() => {
-      // Okay, so the platform is ready and our plugins are available.
-      // Here you can do any higher level native things you might need.
       StatusBar.styleDefault();
       Splashscreen.hide();
+      Diagnostic.isLocationEnabled()
+        .then((enabled) => {
+          if ( !enabled ) {
+            Dialogs.confirm(
+              'Pentru a te putea localiza pe hartă, avem nevoie să pornești locația.', 'Pornești locația?', ['Da', 'Nu']
+            ).then((button) => {
+              if ( button == 1 ) Diagnostic.switchToLocationSettings();
+            });
+          }
+        });
     });
   }
 


### PR DESCRIPTION
#### Rezumat al schimbărilor:

- adaugă dialog nativ pentru locație
- adaugă `cordova-plugin-dialogs` și `cordova.plugins.diagnostic`

#### Test plan:

`ionic run android`, văzut și testat în mai multe scenarii: cu location enabled/disabled și back din ecranul nativ și după enable și după disable location.

![screenshot_2016-12-08-21-52-55](https://cloud.githubusercontent.com/assets/985838/21027157/49dcced6-bd98-11e6-96ab-91eb4bdc5aac.png)

#### Reviewers: @gov-ithub/romanescu-app, @ClaudiuCeia 