### PR TITLE
fix(map/map-view): Wrap text pentru adresa si schimba icon

### DIFF
--- a/src/pages/map-view/map-view.html
+++ b/src/pages/map-view/map-view.html
@@ -29,8 +29,8 @@
 
       <ion-list no-lines>
         <div ion-item>
-          <ion-icon name="flag" item-left></ion-icon>
-          <div class="item item-text-wrap">
+          <ion-icon name="pin" item-left></ion-icon>
+          <div ion-item text-wrap style="padding-left: 0">
             {{ marker.address }}
           </div>
         </div>


### PR DESCRIPTION
#### Rezumat al schimbărilor:
- Wrap-text pentru adrese lungi
- Schimba in loc de icon cu steag in icon cu pin

#### Test plan:
![screen shot 2016-12-09 at 11 17 41 pm](https://cloud.githubusercontent.com/assets/22706412/21064854/f8ee50a2-be65-11e6-8d73-b10f045d28cc.png)

#### Reviewers: @gov-ithub/romanescu-app, @zalog 

