### PR TITLE
fix(pages/feedback): Nu ascunde intrebarile la care s-a raspuns

### DIFF
--- a/src/pages/feedback/feedback.html
+++ b/src/pages/feedback/feedback.html
@@ -25,16 +25,28 @@
     <ion-slide *ngFor="let question of slides">
       <h2>OPINIA TA</h2>
       <p>{{ question.content }}</p>
-      <button
-        *ngFor="let button of question.buttons"
-        ion-button
-        color="{{ button.color }}"
-        (click)="answerQuestion(question.id, button.value)">
-        {{ button.label }}
-      </button>
-      <p>
+      <div *ngIf="question.status.active">
+        <button
+          *ngFor="let button of question.buttons"
+          ion-button
+          color="{{ button.color }}"
+          (click)="answerQuestion(question.id, button.value)">
+          {{ button.label }}
+        </button>
+      </div>
+      <div *ngIf="!question.status.active">
+        <p style="font-size: 1em">
+          {{ question.status.answer }} 
+        </p>
+      </div>
+      <p *ngIf="question.status.active">
         <button clear (click)="nextSlide()" ion-button>
           Răspund mai târziu
+        </button>
+      </p>
+      <p *ngIf="!question.status.active">
+        <button clear (click)="nextSlide()" ion-button icon-only color="dark">
+          <ion-icon name="arrow-forward"></ion-icon>
         </button>
       </p>
     </ion-slide>

--- a/src/pages/feedback/feedback.ts
+++ b/src/pages/feedback/feedback.ts
@@ -36,9 +36,24 @@ export class PageFeedback {
   slides = [];
   
   private allSlides = [
-    {content: 'Ai găsit ușor secția de vot selectată?', id: 1, buttons: DefaultButtons},
-    {content: 'Secția de vot era poziționată corect pe hartă?', id: 2, buttons: DefaultButtons},
-    {content: 'Era aglomerat sau nu la secția de vot?', id: 3, buttons: DefaultButtons},
+    {
+      content: 'Ai găsit ușor secția de vot selectată?', 
+      id: 1, 
+      buttons: DefaultButtons,
+      status: { active: true },
+    },
+    {
+      content: 'Secția de vot era poziționată corect pe hartă?', 
+      id: 2, 
+      buttons: DefaultButtons,
+      status: { active: true },
+    },
+    {
+      content: 'Era aglomerat sau nu la secția de vot?', 
+      id: 3,
+      buttons: DefaultButtons,
+      status: { active: true },
+    },
   ];
   
   constructor(
@@ -52,6 +67,14 @@ export class PageFeedback {
         let slide = this.allSlides[i];
         if (data.indexOf(this.getQuestionKey(slide.id)) == -1) {
           this.slides.push(slide);
+        } else {
+          this.storage.get(this.getQuestionKey(slide.id)).then((val) => {
+            this.slides.push({
+              content: slide.content,
+              id: slide.id,
+              status: { active: false, answer: val === 1 ? 'NU' : 'DA' },
+            });
+          });
         }
       }
     });


### PR DESCRIPTION
#### Rezumat al schimbărilor:
In loc sa ascundem intrebarile dupa raspuns, pentru intrebarile la care s-a raspuns deja:
- Inlocuieste butoanele cu raspunsul acordat
- Inlocuieste "raspund mai tarziu" cu acelasi icon de forward ca si in primul slide

#### Test plan:
![screen shot 2016-12-09 at 11 52 50 pm](https://cloud.githubusercontent.com/assets/22706412/21065806/e23942ae-be6a-11e6-81c7-539dfe49aaeb.png)

#### Reviewers: @gov-ithub/romanescu-app, @zalog 


