### PR TITLE
fix(page/feedback): Back button override

### DIFF
--- a/src/pages/feedback/feedback.html
+++ b/src/pages/feedback/feedback.html
@@ -10,7 +10,7 @@
 </ion-header>
 
 <ion-content scroll="false">
-  <ion-slides #slider [options]="sliderOptions" padding>
+  <ion-slides #slider [options]="sliderOptions" padding (ionDidChange)="onSlideChanged()">
     <ion-slide>
       <h2>OPINIA TA</h2>
       <p>

--- a/src/pages/feedback/feedback.ts
+++ b/src/pages/feedback/feedback.ts
@@ -1,5 +1,5 @@
 import { Component, ViewChild } from '@angular/core';
-import { Slides } from 'ionic-angular';
+import { Slides, Platform } from 'ionic-angular';
 import { Storage } from '@ionic/storage';
 
 import { SocialSharing } from 'ionic-native';
@@ -56,8 +56,11 @@ export class PageFeedback {
     },
   ];
   
+  private unregisterBackButtonOverride; 
+
   constructor(
-    private storage: Storage
+    private storage: Storage,
+    private platform: Platform,
   ) {}
 
   ionViewDidLoad() {
@@ -84,8 +87,26 @@ export class PageFeedback {
     return 'feedback-' + id;
   }
 
+  private registerBackButtonOverride() {
+    this.unregisterBackButtonOverride = this.platform.registerBackButtonAction(
+      () => { this.slider.slidePrev(); },
+      101,
+    );   
+  }
+
   nextSlide() {
     this.slider.slideNext();
+  }
+
+  onSlideChanged() {
+    if (this.slider.isBeginning()) {
+      this.unregisterBackButtonOverride();
+      this.unregisterBackButtonOverride = null;
+    } else {
+      if (!this.unregisterBackButtonOverride) {
+        this.registerBackButtonOverride();
+      }
+    }
   }
 
   answerQuestion(id: number, answer: number) {


### PR DESCRIPTION
#### Rezumat al schimbărilor:
Pagina de feedback este un slider cu mai multe pagini. Momentan avem un bug care ne scoate din aplicatie indiferent pe care pagina a slide-ului suntem atunci cand folosim back button-ul hardware. 

In PR-ul asta:
- Fac override pentru back button atunci cand nu esti pe primul slide care sa te duce inapoi pe slide-ul precedent
- Cand ajungi din nou pe primul slide functionalitatea butonului hardware revine la normal (iesi din aplicatie)
#### Test plan:
`ionic run android`, testat flow-ul de mai sus
#### Reviewers: @gov-ithub/romanescu-app, @zalog 

