### PR TITLE
hotfix(feedback): re-enable back button on page leave

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<widget id="com.ionicframework.romanescuapp2146162" version="0.1.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="com.ionicframework.romanescuapp2146162" version="0.1.2" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
   <name>ROdiaspora</name>
   <description>Aplicația românilor de pretutindeni.</description>
   <author email="team@govithub.gov.ro" href="http://ithub.gov.ro">GovITHub</author>

--- a/src/pages/feedback/feedback.ts
+++ b/src/pages/feedback/feedback.ts
@@ -83,6 +83,11 @@ export class PageFeedback {
     });
   }
 
+  ionViewDidLeave() {
+    this.unregisterBackButtonOverride();
+    this.unregisterBackButtonOverride = null;
+  }
+
   private getQuestionKey(id: number) {
     return 'feedback-' + id;
   }


### PR DESCRIPTION
#### Rezumat al schimbărilor:
Utilizatorii pot iesi din pagina de feedback din burger menu. Daca fac asta cat timp nu sunt pe primul slide vor ramane cu butonul de back disabled pe Android. PR-ul asta rezolva problema.
#### Test plan:
`ionic run android`
#### Reviewers: @gov-ithub/romanescu-app, @zalog 

